### PR TITLE
Add option: notification on playback resume

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -492,7 +492,7 @@ MainWindow::MainWindow(Application *app, SystemTrayIcon *tray_icon, OSD *osd, co
   connect(app_->player(), SIGNAL(Stopped()), ui_->playlist, SLOT(ActiveStopped()));
 
   connect(app_->player(), SIGNAL(Paused()), osd_, SLOT(Paused()));
-  connect(app_->player(), SIGNAL(Playing()), osd_, SLOT(Resumed()));
+  connect(app_->player(), SIGNAL(Resumed()), osd_, SLOT(Resumed()));
   connect(app_->player(), SIGNAL(Stopped()), osd_, SLOT(Stopped()));
   connect(app_->player(), SIGNAL(PlaylistFinished()), osd_, SLOT(PlaylistFinished()));
   connect(app_->player(), SIGNAL(VolumeChanged(int)), osd_, SLOT(VolumeChanged(int)));

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -492,6 +492,7 @@ MainWindow::MainWindow(Application *app, SystemTrayIcon *tray_icon, OSD *osd, co
   connect(app_->player(), SIGNAL(Stopped()), ui_->playlist, SLOT(ActiveStopped()));
 
   connect(app_->player(), SIGNAL(Paused()), osd_, SLOT(Paused()));
+  connect(app_->player(), SIGNAL(Playing()), osd_, SLOT(Resumed()));
   connect(app_->player(), SIGNAL(Stopped()), osd_, SLOT(Stopped()));
   connect(app_->player(), SIGNAL(PlaylistFinished()), osd_, SLOT(PlaylistFinished()));
   connect(app_->player(), SIGNAL(VolumeChanged(int)), osd_, SLOT(VolumeChanged(int)));

--- a/src/core/player.cpp
+++ b/src/core/player.cpp
@@ -450,6 +450,7 @@ void Player::PlayPause() {
   switch (engine_->state()) {
     case Engine::Paused:
       engine_->Unpause();
+      emit Resumed();
       break;
 
     case Engine::Playing: {

--- a/src/core/player.h
+++ b/src/core/player.h
@@ -104,6 +104,8 @@ class PlayerInterface : public QObject {
  signals:
   void Playing();
   void Paused();
+  // Emitted only when playback is manually resumed
+  void Resumed();
   void Stopped();
   void Error();
   void PlaylistFinished();

--- a/src/settings/notificationssettingspage.cpp
+++ b/src/settings/notificationssettingspage.cpp
@@ -169,6 +169,7 @@ void NotificationsSettingsPage::Load() {
   ui_->notifications_volume->setChecked( s.value("ShowOnVolumeChange", false).toBool());
   ui_->notifications_play_mode->setChecked( s.value("ShowOnPlayModeChange", true).toBool());
   ui_->notifications_pause->setChecked(s.value("ShowOnPausePlayback", true).toBool());
+  ui_->notifications_resume->setChecked(s.value("ShowOnResumePlayback", false).toBool());
   ui_->notifications_art->setChecked(s.value("ShowArt", true).toBool());
   ui_->notifications_custom_text_enabled->setChecked(s.value("CustomTextEnabled", false).toBool());
   ui_->notifications_custom_text1->setText(s.value("CustomText1").toString());
@@ -211,6 +212,7 @@ void NotificationsSettingsPage::Save() {
   s.setValue("ShowOnVolumeChange", ui_->notifications_volume->isChecked());
   s.setValue("ShowOnPlayModeChange", ui_->notifications_play_mode->isChecked());
   s.setValue("ShowOnPausePlayback", ui_->notifications_pause->isChecked());
+  s.setValue("ShowOnResumePlayback", ui_->notifications_resume->isChecked());
   s.setValue("ShowArt", ui_->notifications_art->isChecked());
   s.setValue("CustomTextEnabled", ui_->notifications_custom_text_enabled->isChecked());
   s.setValue("CustomText1", ui_->notifications_custom_text1->text());

--- a/src/settings/notificationssettingspage.ui
+++ b/src/settings/notificationssettingspage.ui
@@ -148,6 +148,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QCheckBox" name="notifications_resume">
+        <property name="text">
+         <string>Show a notification when I resume playback</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QCheckBox" name="notifications_art">
         <property name="text">
          <string>Include album art in the notification</string>

--- a/src/widgets/osd.cpp
+++ b/src/widgets/osd.cpp
@@ -186,9 +186,9 @@ void OSD::Paused() {
 }
 
 void OSD::Resumed() {
-    if (show_on_resume_) {
-        AlbumArtLoaded(last_song_, last_image_uri_, last_image_);
-    }
+  if (show_on_resume_) {
+    AlbumArtLoaded(last_song_, last_image_uri_, last_image_);
+  }
 }
 
 void OSD::Stopped() {

--- a/src/widgets/osd.cpp
+++ b/src/widgets/osd.cpp
@@ -58,6 +58,7 @@ OSD::OSD(SystemTrayIcon *tray_icon, Application *app, QObject *parent)
       show_art_(true),
       show_on_play_mode_change_(true),
       show_on_pause_(true),
+      show_on_resume_(false),
       use_custom_text_(false),
       custom_text1_(QString()),
       custom_text2_(QString()),
@@ -90,6 +91,7 @@ void OSD::ReloadSettings() {
   show_art_ = s.value("ShowArt", true).toBool();
   show_on_play_mode_change_ = s.value("ShowOnPlayModeChange", true).toBool();
   show_on_pause_ = s.value("ShowOnPausePlayback", true).toBool();
+  show_on_resume_ = s.value("ShowOnResumePlayback", false).toBool();
   use_custom_text_ = s.value(("CustomTextEnabled"), false).toBool();
   custom_text1_ = s.value("CustomText1").toString();
   custom_text2_ = s.value("CustomText2").toString();
@@ -181,6 +183,12 @@ void OSD::Paused() {
   if (show_on_pause_) {
     ShowMessage(app_name_, tr("Paused"));
   }
+}
+
+void OSD::Resumed() {
+    if (show_on_resume_) {
+        AlbumArtLoaded(last_song_, last_image_uri_, last_image_);
+    }
 }
 
 void OSD::Stopped() {

--- a/src/widgets/osd.h
+++ b/src/widgets/osd.h
@@ -80,6 +80,7 @@ class OSD : public QObject {
   void ReloadSettings();
 
   void Paused();
+  void Resumed();
   void Stopped();
   void StopAfterToggle(bool stop);
   void PlaylistFinished();
@@ -115,6 +116,7 @@ class OSD : public QObject {
   bool show_art_;
   bool show_on_play_mode_change_;
   bool show_on_pause_;
+  bool show_on_resume_;
   bool use_custom_text_;
   QString custom_text1_;
   QString custom_text2_;


### PR DESCRIPTION
This adds an optional setting to show the notification that is displayed when changing the track,
when resuming playback as well.


While everything works fine for me, there are a few things I'm unsure of.
  * the inconsistency between "playing" and "resumed" for the signal and slot
  * the fact that although the options for a notification on pause and the added on resume look similar,
they do totally different things (one showing only the "Paused" text and the other showing track information)