### PR TITLE
Modify stretch background image functionality

### DIFF
--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -832,8 +832,8 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
             }
           }
           else {
-            int resize_width = qMin(qMin(background_image_.size().width(), (pb_width >= 50 ? (pb_width - 25) : pb_width)), background_image_maxsize_);
-            int resize_height = qMin(qMin(background_image_.size().height(), (pb_height >= 50 ? (pb_height - 25) : pb_height)), background_image_maxsize_);
+            int resize_width = qMin(qMin(background_image_.size().width(), pb_width), background_image_maxsize_);
+            int resize_height = qMin(qMin(background_image_.size().height(), pb_height), background_image_maxsize_);
             cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaled(resize_width, resize_height, Qt::KeepAspectRatio, Qt::SmoothTransformation));
           }
         }
@@ -855,7 +855,7 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
             current_background_image_y_ = 0;
             break;
           case AppearanceSettingsPage::BackgroundImagePosition_UpperRight:
-            current_background_image_x_ = (pb_width - cached_scaled_background_image_.width() - 0);
+            current_background_image_x_ = (pb_width - cached_scaled_background_image_.width());
             current_background_image_y_ = 0;
             break;
           case AppearanceSettingsPage::BackgroundImagePosition_Middle:
@@ -864,12 +864,12 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
             break;
           case AppearanceSettingsPage::BackgroundImagePosition_BottomLeft:
             current_background_image_x_ = 0;
-            current_background_image_y_ = (pb_height - cached_scaled_background_image_.height() - 25);
+            current_background_image_y_ = (pb_height - cached_scaled_background_image_.height());
             break;
           case AppearanceSettingsPage::BackgroundImagePosition_BottomRight:
           default:
-            current_background_image_x_ = (pb_width - cached_scaled_background_image_.width() - 0);
-            current_background_image_y_ = (pb_height - cached_scaled_background_image_.height() - 25);
+            current_background_image_x_ = (pb_width - cached_scaled_background_image_.width());
+            current_background_image_y_ = (pb_height - cached_scaled_background_image_.height());
         }
         background_painter.drawPixmap(current_background_image_x_, current_background_image_y_, cached_scaled_background_image_);
       }

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -136,6 +136,7 @@ PlaylistView::PlaylistView(QWidget *parent)
       background_image_position_(AppearanceSettingsPage::BackgroundImagePosition_BottomRight),
       background_image_maxsize_(0),
       background_image_stretch_(false),
+      background_image_do_not_cut_(true),
       background_image_keep_aspect_ratio_(true),
       blur_radius_(AppearanceSettingsPage::kDefaultBlurRadius),
       opacity_level_(AppearanceSettingsPage::kDefaultOpacityLevel),
@@ -811,11 +812,16 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
         else {
           if (background_image_stretch_) {
             if (background_image_keep_aspect_ratio_) {
-              if (height() >= width()){
-                cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaledToHeight(height(), Qt::SmoothTransformation));
+              if (background_image_do_not_cut_){
+                cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaled(width(), height(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
               }
               else {
-                cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaledToWidth(width(), Qt::SmoothTransformation));
+                if (height() >= width()){
+                  cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaledToHeight(height(), Qt::SmoothTransformation));
+                }
+                else {
+                  cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaledToWidth(width(), Qt::SmoothTransformation));
+                }
               }
             }
             else {
@@ -992,6 +998,7 @@ void PlaylistView::ReloadSettings() {
   if (background_image_maxsize <= 10) background_image_maxsize = 9000;
   QString background_image_filename = s.value(AppearanceSettingsPage::kBackgroundImageFilename).toString();
   bool background_image_stretch = s.value(AppearanceSettingsPage::kBackgroundImageStretch, false).toBool();
+  bool background_image_do_not_cut = s.value(AppearanceSettingsPage::kBackgroundImageDoNotCut, true).toBool();
   bool background_image_keep_aspect_ratio = s.value(AppearanceSettingsPage::kBackgroundImageKeepAspectRatio, true).toBool();
   int blur_radius = s.value(AppearanceSettingsPage::kBlurRadius, AppearanceSettingsPage::kDefaultBlurRadius).toInt();
   int opacity_level = s.value(AppearanceSettingsPage::kOpacityLevel, AppearanceSettingsPage::kDefaultOpacityLevel).toInt();
@@ -1054,6 +1061,7 @@ void PlaylistView::ReloadSettings() {
       background_image_position != background_image_position_ ||
       background_image_maxsize != background_image_maxsize_ ||
       background_image_stretch != background_image_stretch_ ||
+      background_image_do_not_cut != background_image_do_not_cut_ ||
       background_image_keep_aspect_ratio != background_image_keep_aspect_ratio_ ||
       blur_radius_ != blur_radius ||
       opacity_level_ != opacity_level
@@ -1065,6 +1073,7 @@ void PlaylistView::ReloadSettings() {
     background_image_position_ = background_image_position;
     background_image_maxsize_ = background_image_maxsize;
     background_image_stretch_ = background_image_stretch;
+    background_image_do_not_cut_ = background_image_do_not_cut;
     background_image_keep_aspect_ratio_ = background_image_keep_aspect_ratio;
     blur_radius_ = blur_radius;
     opacity_level_ = opacity_level;

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -803,8 +803,11 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
     if (!background_image_.isNull() || !previous_background_image_.isNull()) {
       QPainter background_painter(viewport());
 
+      int pb_height = height() - header_->height();
+      int pb_width = width() - style()->pixelMetric(QStyle::PM_ScrollBarExtent);
+
       // Check if we should recompute the background image
-      if (height() != last_height_ || width() != last_width_ || force_background_redraw_) {
+      if (pb_height != last_height_ || pb_width != last_width_ || force_background_redraw_) {
 
         if (background_image_.isNull()) {
           cached_scaled_background_image_ = QPixmap();
@@ -813,30 +816,30 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
           if (background_image_stretch_) {
             if (background_image_keep_aspect_ratio_) {
               if (background_image_do_not_cut_){
-                cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaled(width(), height(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+                cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaled(pb_width, pb_height, Qt::KeepAspectRatio, Qt::SmoothTransformation));
               }
               else {
-                if (height() >= width()){
-                  cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaledToHeight(height(), Qt::SmoothTransformation));
+                if (pb_height >= pb_width){
+                  cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaledToHeight(pb_height, Qt::SmoothTransformation));
                 }
                 else {
-                  cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaledToWidth(width(), Qt::SmoothTransformation));
+                  cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaledToWidth(pb_width, Qt::SmoothTransformation));
                 }
               }
             }
             else {
-              cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaled(width(), height(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+              cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaled(pb_width, pb_height, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
             }
           }
           else {
-            int resize_width = qMin(qMin(background_image_.size().width(), (width() >= 50 ? (width() - 25) : width())), background_image_maxsize_);
-            int resize_height = qMin(qMin(background_image_.size().height(), (height() >= 50 ? (height() - 25) : height())), background_image_maxsize_);
+            int resize_width = qMin(qMin(background_image_.size().width(), (pb_width >= 50 ? (pb_width - 25) : pb_width)), background_image_maxsize_);
+            int resize_height = qMin(qMin(background_image_.size().height(), (pb_height >= 50 ? (pb_height - 25) : pb_height)), background_image_maxsize_);
             cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaled(resize_width, resize_height, Qt::KeepAspectRatio, Qt::SmoothTransformation));
           }
         }
 
-        last_height_ = height();
-        last_width_ = width();
+        last_height_ = pb_height;
+        last_width_ = pb_width;
         force_background_redraw_ = false;
       }
 
@@ -852,21 +855,21 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
             current_background_image_y_ = 0;
             break;
           case AppearanceSettingsPage::BackgroundImagePosition_UpperRight:
-            current_background_image_x_ = (width() - cached_scaled_background_image_.width() - 0);
+            current_background_image_x_ = (pb_width - cached_scaled_background_image_.width() - 0);
             current_background_image_y_ = 0;
             break;
           case AppearanceSettingsPage::BackgroundImagePosition_Middle:
-            current_background_image_x_ = ((width() - cached_scaled_background_image_.width()) / 2);
-            current_background_image_y_ = ((height() - cached_scaled_background_image_.height()) / 2);
+            current_background_image_x_ = ((pb_width - cached_scaled_background_image_.width()) / 2);
+            current_background_image_y_ = ((pb_height - cached_scaled_background_image_.height()) / 2);
             break;
           case AppearanceSettingsPage::BackgroundImagePosition_BottomLeft:
             current_background_image_x_ = 0;
-            current_background_image_y_ = (height() - cached_scaled_background_image_.height() - 25);
+            current_background_image_y_ = (pb_height - cached_scaled_background_image_.height() - 25);
             break;
           case AppearanceSettingsPage::BackgroundImagePosition_BottomRight:
           default:
-            current_background_image_x_ = (width() - cached_scaled_background_image_.width() - 0);
-            current_background_image_y_ = (height() - cached_scaled_background_image_.height() - 25);
+            current_background_image_x_ = (pb_width - cached_scaled_background_image_.width() - 0);
+            current_background_image_y_ = (pb_height - cached_scaled_background_image_.height() - 25);
         }
         background_painter.drawPixmap(current_background_image_x_, current_background_image_y_, cached_scaled_background_image_);
       }

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -804,7 +804,7 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
       QPainter background_painter(viewport());
 
       int pb_height = height() - header_->height();
-      int pb_width = width() - style()->pixelMetric(QStyle::PM_ScrollBarExtent);
+      int pb_width = verticalScrollBar()->isVisible() ? width() - style()->pixelMetric(QStyle::PM_ScrollBarExtent) : width();
 
       // Check if we should recompute the background image
       if (pb_height != last_height_ || pb_width != last_width_ || force_background_redraw_) {

--- a/src/playlist/playlistview.cpp
+++ b/src/playlist/playlistview.cpp
@@ -811,7 +811,12 @@ void PlaylistView::paintEvent(QPaintEvent *event) {
         else {
           if (background_image_stretch_) {
             if (background_image_keep_aspect_ratio_) {
-              cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaled(width(), height(), Qt::KeepAspectRatio, Qt::SmoothTransformation));
+              if (height() >= width()){
+                cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaledToHeight(height(), Qt::SmoothTransformation));
+              }
+              else {
+                cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaledToWidth(width(), Qt::SmoothTransformation));
+              }
             }
             else {
               cached_scaled_background_image_ = QPixmap::fromImage(background_image_.scaled(width(), height(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation));

--- a/src/playlist/playlistview.h
+++ b/src/playlist/playlistview.h
@@ -207,6 +207,7 @@ class PlaylistView : public QTreeView {
   AppearanceSettingsPage::BackgroundImagePosition background_image_position_;
   int background_image_maxsize_;
   bool background_image_stretch_;
+  bool background_image_do_not_cut_;
   bool background_image_keep_aspect_ratio_;
   int blur_radius_;
   int opacity_level_;

--- a/src/settings/appearancesettingspage.cpp
+++ b/src/settings/appearancesettingspage.cpp
@@ -52,6 +52,7 @@ const char *AppearanceSettingsPage::kBackgroundImageType = "background_image_typ
 const char *AppearanceSettingsPage::kBackgroundImageFilename = "background_image_file";
 const char *AppearanceSettingsPage::kBackgroundImagePosition = "background_image_position";
 const char *AppearanceSettingsPage::kBackgroundImageStretch = "background_image_stretch";
+const char *AppearanceSettingsPage::kBackgroundImageDoNotCut = "background_image_do_not_cut";
 const char *AppearanceSettingsPage::kBackgroundImageKeepAspectRatio = "background_image_keep_aspect_ratio";
 const char *AppearanceSettingsPage::kBackgroundImageMaxSize = "background_image_max_size";
 
@@ -94,6 +95,7 @@ AppearanceSettingsPage::AppearanceSettingsPage(SettingsDialog *dialog)
   connect(ui_->use_custom_background_image, SIGNAL(toggled(bool)), ui_->background_image_filename, SLOT(setEnabled(bool)));
   connect(ui_->use_custom_background_image, SIGNAL(toggled(bool)), ui_->select_background_image_filename_button, SLOT(setEnabled(bool)));
 
+  connect(ui_->checkbox_background_image_stretch, SIGNAL(toggled(bool)), ui_->checkbox_background_image_do_not_cut, SLOT(setEnabled(bool)));
   connect(ui_->checkbox_background_image_stretch, SIGNAL(toggled(bool)), ui_->checkbox_background_image_keep_aspect_ratio, SLOT(setEnabled(bool)));
   connect(ui_->checkbox_background_image_stretch, SIGNAL(toggled(bool)), ui_->spinbox_background_image_maxsize, SLOT(setDisabled(bool)));
 
@@ -151,12 +153,16 @@ void AppearanceSettingsPage::Load() {
   ui_->combobox_backgroundimageposition->setCurrentIndex(ui_->combobox_backgroundimageposition->findData(s.value(kBackgroundImagePosition, BackgroundImagePosition_BottomRight).toInt()));
   ui_->spinbox_background_image_maxsize->setValue(s.value(kBackgroundImageMaxSize, 0).toInt());
   ui_->checkbox_background_image_stretch->setChecked(s.value(kBackgroundImageStretch, false).toBool());
+  ui_->checkbox_background_image_do_not_cut->setChecked(s.value(kBackgroundImageDoNotCut, true).toBool());
   ui_->checkbox_background_image_keep_aspect_ratio->setChecked(s.value(kBackgroundImageKeepAspectRatio, true).toBool());
   ui_->blur_slider->setValue(s.value(kBlurRadius, kDefaultBlurRadius).toInt());
   ui_->opacity_slider->setValue(s.value(kOpacityLevel, kDefaultOpacityLevel).toInt());
   ui_->checkbox_system_icons->setChecked(s.value(kSystemThemeIcons, false).toBool());
 
-  if (!ui_->checkbox_background_image_stretch->isChecked()) ui_->checkbox_background_image_keep_aspect_ratio->setDisabled(true);
+  if (!ui_->checkbox_background_image_stretch->isChecked()) {
+    ui_->checkbox_background_image_do_not_cut->setDisabled(true);
+    ui_->checkbox_background_image_keep_aspect_ratio->setDisabled(true);
+  }
 
   s.endGroup();
 
@@ -201,6 +207,7 @@ void AppearanceSettingsPage::Save() {
   s.setValue(kBackgroundImageMaxSize, ui_->spinbox_background_image_maxsize->value());
   s.setValue(kBackgroundImagePosition, backgroundimageposition);
   s.setValue(kBackgroundImageStretch, ui_->checkbox_background_image_stretch->isChecked());
+  s.setValue(kBackgroundImageDoNotCut, ui_->checkbox_background_image_do_not_cut->isChecked());
   s.setValue(kBackgroundImageKeepAspectRatio, ui_->checkbox_background_image_keep_aspect_ratio->isChecked());
 
   s.setValue(kBlurRadius, ui_->blur_slider->value());

--- a/src/settings/appearancesettingspage.h
+++ b/src/settings/appearancesettingspage.h
@@ -52,6 +52,7 @@ public:
   static const char *kBackgroundImageFilename;
   static const char *kBackgroundImagePosition;
   static const char *kBackgroundImageStretch;
+  static const char *kBackgroundImageDoNotCut;
   static const char *kBackgroundImageKeepAspectRatio;
   static const char *kBackgroundImageMaxSize;
 

--- a/src/settings/appearancesettingspage.ui
+++ b/src/settings/appearancesettingspage.ui
@@ -269,6 +269,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="checkbox_background_image_do_not_cut">
+              <property name="text">
+               <string>Do not cut image</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QCheckBox" name="checkbox_background_image_keep_aspect_ratio">
               <property name="text">
                <string>Keep aspect ratio</string>


### PR DESCRIPTION
Changes the stretch functionality to fill out
the playlist background completely by zooming
the image (if keep aspect ratio is selected)
instead of filling it only height-wise.

I thought about adding a new zoom option in the settings, but
I think "stretch background image to fill playlist background"
should actually fill the *entire* background instead of what
it did before.
This will resolve #177 