### PR TITLE
Make playlist ignore articles when sorting

### DIFF
--- a/src/collection/collectionmodel.cpp
+++ b/src/collection/collectionmodel.cpp
@@ -1286,14 +1286,12 @@ QString CollectionModel::SortTextForArtist(QString artist) {
 
   artist = SortText(artist);
 
-  if (artist.startsWith("the ")) {
-    artist = artist.right(artist.length() - 4) + ", the";
-  }
-  else if (artist.startsWith("a ")) {
-    artist = artist.right(artist.length() - 2) + ", a";
-  }
-  else if (artist.startsWith("an ")) {
-    artist = artist.right(artist.length() - 3) + ", an";
+  for (const auto &i : Song::kArticles) {
+    if (artist.startsWith(i)) {
+      int ilen = i.length();
+      artist = artist.right(artist.length() - ilen) + ", " + i.left(ilen - 1);
+      break;
+    }
   }
 
   return artist;

--- a/src/core/song.h
+++ b/src/core/song.h
@@ -126,6 +126,8 @@ class Song {
   static const QRegExp kTitleRemoveMisc;
   static const QRegExp kFilenameRemoveNonFatChars;
 
+  static const QStringList kArticles;
+
   static QString JoinSpec(const QString &table);
 
   static Source SourceFromURL(const QUrl &url);
@@ -184,7 +186,9 @@ class Song {
   int id() const;
 
   const QString &title() const;
+  const QString &title_sortable() const;
   const QString &album() const;
+  const QString &album_sortable() const;
   const QString &artist() const;
   const QString &albumartist() const;
   int track() const;
@@ -342,6 +346,8 @@ class Song {
 
  private:
   struct Private;
+
+  QString sortable(const QString &v) const;
 
   QSharedDataPointer<Private> d;
 };

--- a/src/playlist/playlist.cpp
+++ b/src/playlist/playlist.cpp
@@ -1102,9 +1102,9 @@ bool Playlist::CompareItems(int column, Qt::SortOrder order, shared_ptr<Playlist
 
   switch (column) {
 
-    case Column_Title:        strcmp(title);
+    case Column_Title:        strcmp(title_sortable);
     case Column_Artist:       strcmp(artist);
-    case Column_Album:        strcmp(album);
+    case Column_Album:        strcmp(album_sortable);
     case Column_Length:       cmp(length_nanosec);
     case Column_Track:        cmp(track);
     case Column_Disc:         cmp(disc);


### PR DESCRIPTION
This is more correct, and the other way is driving me crazy.

On the note about using `queue2`: when I built with it, not only did it solve the problem I had with `flac` files,  it seemed to have solved my other problems as well, except for this one. I am doing this one first, and then I will start trying to reproduce the problem with `queue2`. I just didn't want to put two different changes into one PR.