### PR TITLE
Enable About Strawberry and QT menu on macOS

### DIFF
--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -248,9 +248,6 @@ MainWindow::MainWindow(Application *app, SystemTrayIcon *tray_icon, OSD *osd, co
 
   // Initialise the UI
   ui_->setupUi(this);
-#ifdef Q_OS_MACOS
-  ui_->menu_help->menuAction()->setVisible(true);
-#endif
 
   connect(app_->current_albumcover_loader(), SIGNAL(AlbumCoverLoaded(Song, QUrl, QImage)), SLOT(AlbumCoverLoaded(Song, QUrl, QImage)));
   album_cover_choice_controller_->Init(app);

--- a/src/core/mainwindow.cpp
+++ b/src/core/mainwindow.cpp
@@ -249,7 +249,7 @@ MainWindow::MainWindow(Application *app, SystemTrayIcon *tray_icon, OSD *osd, co
   // Initialise the UI
   ui_->setupUi(this);
 #ifdef Q_OS_MACOS
-  ui_->menu_help->menuAction()->setVisible(false);
+  ui_->menu_help->menuAction()->setVisible(true);
 #endif
 
   connect(app_->current_albumcover_loader(), SIGNAL(AlbumCoverLoaded(Song, QUrl, QImage)), SLOT(AlbumCoverLoaded(Song, QUrl, QImage)));


### PR DESCRIPTION
I wonder the reason why these menus were disabled.. I thought to enable them.