### PR TITLE
subsonic api returns discNumber, not disc

### DIFF
--- a/src/subsonic/subsonicrequest.cpp
+++ b/src/subsonic/subsonicrequest.cpp
@@ -533,9 +533,9 @@ int SubsonicRequest::ParseSong(Song &song, const QJsonObject &json_obj, const qi
   if (json_obj.contains("year")) year = json_obj["year"].toInt();
 
   int disc = 0;
-  if (json_obj.contains("disc")) {
-    disc = json_obj["disc"].toString().toInt();
-    if (disc == 0) disc = json_obj["disc"].toInt();
+  if (json_obj.contains("discNumber")) {
+    disc = json_obj["discNumber"].toString().toInt();
+    if (disc == 0) disc = json_obj["discNumber"].toInt();
   }
 
   int track = 0;


### PR DESCRIPTION
As found in the v1.13.0 xsd, the disc is named discNumber in the api,
currently there is a check for disc which will never be found in the
response.

@see http://www.subsonic.org/pages/inc/api/schema/subsonic-rest-api-1.13.0.xsd

Signed-off-by: BlackEagle <ike.devolder@gmail.com>